### PR TITLE
Fix typo in workshop description

### DIFF
--- a/steamworkshop/STEAMWORSHOP_DESCRIPTION.md
+++ b/steamworkshop/STEAMWORSHOP_DESCRIPTION.md
@@ -15,7 +15,7 @@ Stage: Alpha
 
 [h2] What's Not Implemented [/h2]
 [list]
- [*] Syncronisation of duplicants (planned for future updates).
+ [*] Synchronization of duplicants (planned for future updates).
  [*] Support for DLC content (planned for future updates).
  [*] Different game mods (e.g. living on different asteroids, controlling different dupes, etc).
 [/list]


### PR DESCRIPTION
## Summary
- correct `Syncronisation` to `Synchronization` in the Steam workshop description

## Testing
- `pre-commit` *(fails: no pre-commit configs)*

------
https://chatgpt.com/codex/tasks/task_e_684d816a6c3083289e8953810d249816