### PR TITLE
Fix fragment count calculation

### DIFF
--- a/src/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageFactory.cs
+++ b/src/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageFactory.cs
@@ -15,7 +15,7 @@ public class NetworkMessageFactory {
             yield break;
         }
 
-        var fragmentsCount = (int) message.Size / MaxFragmentDataSize + 1;
+        var fragmentsCount = (int) ((message.Size + MaxFragmentDataSize - 1) / MaxFragmentDataSize);
         var header = new NetworkMessageFragmentsHeader(fragmentsCount);
         var serializedHeader = NetworkSerializer.Serialize(header);
         yield return serializedHeader;


### PR DESCRIPTION
## Summary
- adjust message fragmentation to correctly compute the number of fragments

## Testing
- `dotnet build src/MultiplayerMod.Test/MultiplayerMod.Test.csproj -v minimal` *(fails: Property SourceAssemblies isn't set)*
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_684d8012da388328af182096ced0569e