### PR TITLE
Fix fragment count calculation

### DIFF
--- a/src/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageFactory.cs
+++ b/src/MultiplayerMod/Platform/Steam/Network/Messaging/NetworkMessageFactory.cs
@@ -15,7 +15,7 @@ public class NetworkMessageFactory {
             yield break;
         }
 
-        var fragmentsCount = (int) message.Size / MaxFragmentDataSize + 1;
+        var fragmentsCount = (int) ((message.Size + MaxFragmentDataSize - 1) / MaxFragmentDataSize);
         var header = new NetworkMessageFragmentsHeader(fragmentsCount);
         var serializedHeader = NetworkSerializer.Serialize(header);
         yield return serializedHeader;


### PR DESCRIPTION
## Summary
- fix fragment count logic for large network messages

## Testing
- `dotnet test OniMod.sln --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_684d816fb1808328b4b27e0f3a913150