### PR TITLE
Add sync-needed event for debug mismatch

### DIFF
--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
@@ -50,7 +50,7 @@ public class HostEventsBinder {
             return;
 
         subscriptions = [
-            events.Subscribe<WorldSavedEvent>(_ => worldManager.Sync()),
+            events.Subscribe<WorldSyncNeededEvent>(_ => worldManager.Sync()),
             events.Subscribe<DebugSnapshotAvailableEvent>(e => server.Send(new SyncWorldDebugSnapshot(e.Snapshot)))
         ];
     }

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Events/WorldSyncNeededEvent.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Events/WorldSyncNeededEvent.cs
@@ -1,0 +1,5 @@
+using MultiplayerMod.Core.Events;
+
+namespace MultiplayerMod.Multiplayer.CoreOperations.Events;
+
+public record WorldSyncNeededEvent : IDispatchableEvent;

--- a/src/MultiplayerMod/Multiplayer/World/Debug/WorldDebugSnapshotRunner.cs
+++ b/src/MultiplayerMod/Multiplayer/World/Debug/WorldDebugSnapshotRunner.cs
@@ -2,6 +2,7 @@ using System;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Events;
 using MultiplayerMod.Core.Unity;
+using MultiplayerMod.Multiplayer.CoreOperations.Events;
 using UnityEngine;
 
 namespace MultiplayerMod.Multiplayer.World.Debug;
@@ -11,6 +12,7 @@ public class WorldDebugSnapshotRunner : MultiplayerKMonoBehaviour, IRenderEveryT
     private WorldDebugSnapshot? current;
 
     private const float checkPeriod = 30.0f;
+    private const int SyncErrorThreshold = 500;
     private float lastTime;
     public static WorldDebugSnapshot? LastServerInfo { private get; set; }
 
@@ -37,6 +39,8 @@ public class WorldDebugSnapshotRunner : MultiplayerKMonoBehaviour, IRenderEveryT
             return;
 
         ErrorsCount = current != null ? WorldDebugSnapshotComparator.Compare(current, LastServerInfo, true) : 0;
+        if (ErrorsCount >= SyncErrorThreshold)
+            eventDispatcher.Dispatch(new WorldSyncNeededEvent());
         LastServerInfo = null;
     }
 


### PR DESCRIPTION
## Summary
- define a threshold for world debug sync errors
- dispatch `WorldSyncNeededEvent` when error count exceeds threshold
- subscribe host to `WorldSyncNeededEvent` to trigger a world sync
- stop syncing on every save to avoid needless hard syncs

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d869ee9288328b898023f30079e0a